### PR TITLE
fix: Modify entry command for Google docstring hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: google-docstring-inline-summaries
         name: Enforce inline Google docstring summaries
-        entry: uv run python scripts/check_google_docstring_inline_descriptions.py
+        entry: python scripts/check_google_docstring_inline_descriptions.py
         language: system
         pass_filenames: true
         files: ^opt/(abstract_optimizer\.py|multi_objective/abstract_multi_objective\.py)$


### PR DESCRIPTION
This pull request makes a minor update to the pre-commit configuration. The change updates the command used to enforce inline Google docstring summaries, switching from using `uv run` to invoking Python directly.

- Pre-commit configuration:
  * [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L22-R22): Changed the `entry` for the `google-docstring-inline-summaries` hook to use `python` instead of `uv run python`, simplifying the command.