### PR TITLE
feat: Complete Phase 4/5 — ECharts wiring, Griffe API loader, BenchmarkCharts, CLAUDE.md

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'docs/**'
+      - 'opt/**'
       - '.github/workflows/docs.yaml'
   workflow_dispatch:
 
@@ -28,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: docs/package.json
 
@@ -52,13 +53,27 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: docs/package.json
 
-      - name: Install dependencies
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install Python dependencies
+        run: uv sync --group dev
+
+      - name: Regenerate Griffe API JSON
+        run: uv run python scripts/generate_docs.py --json --griffe --full-api
+
+      - name: Install Node dependencies
         working-directory: docs
-        run: npm install
+        run: npm ci
 
       - name: Validate documentation migration
         working-directory: docs

--- a/.gitignore
+++ b/.gitignore
@@ -209,8 +209,9 @@ Temporary Items
 .apdisk
 
 
-# VitePress build output
-docs/.vitepress/
+# VitePress build output (dist/cache only; theme/config/loaders are tracked)
+docs/.vitepress/dist/
+docs/.vitepress/cache/
 docs/docs/.vitepress/
 /.vitepress/
 node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,161 @@
+# useful-optimizer — Claude Code Guide
+
+## Project Overview
+
+Python library of 120+ optimization algorithms (PSO, DE, SGO, etc.) with a VitePress documentation site featuring scientific benchmark visualizations. Package name: `useful-optimizer`, import root: `opt`.
+
+## Tooling
+
+- **Package manager**: `uv` (not pip/poetry)
+- **Linter/formatter**: `ruff` — runs on pre-commit; auto-fixes on commit
+- **Tests**: `pytest` with `--doctest-modules` (doctests in every optimizer file are part of the test suite)
+- **Docs**: VitePress 1.5 in `docs/`, Node 24+
+
+## Common Commands
+
+```bash
+# Python
+uv sync --all-extras          # install all deps including dev/benchmark/validate
+uv run pytest                 # run tests + doctests
+uv run ruff check opt/        # lint
+uv run ruff format opt/       # format
+
+# Docs
+cd docs && npm run docs:dev    # dev server
+cd docs && npm run docs:build  # production build (runs SSR — must be SSR-safe)
+cd docs && npm run docs:api    # regenerate Griffe JSON API files
+
+# Benchmarks
+uv run python benchmarks/run_benchmark_suite.py --output-dir benchmarks/output
+```
+
+## Repository Structure
+
+```
+opt/                        # Python package (120+ optimizers)
+  abstract/                 # AbstractOptimizer base class
+  swarm_intelligence/       # 56 files
+  evolutionary/             # 6 files
+  gradient_based/           # 11 files
+  classical/                # 9 files
+  metaheuristic/            # 15 files
+  physics_inspired/         # 4 files
+  probabilistic/            # 5 files
+  social_inspired/          # 4 files
+  constrained/              # 5 files
+  multi_objective/          # 3 files
+  benchmark/                # benchmark functions (shifted_ackley, rosenbrock, sphere…)
+
+benchmarks/                 # CI benchmark pipeline
+  run_benchmark_suite.py    # main runner (produces benchmark-results.json)
+  generate_plots.py         # matplotlib plots from results
+  aggregate_results.py      # aggregation utilities
+
+docs/                       # VitePress documentation site
+  .vitepress/
+    config.ts               # VitePress config + Catppuccin Mocha theme
+    loaders/api.data.ts     # VitePress data loader: Griffe JSON → typed API
+    theme/
+      index.ts              # Theme entry — see SSR note below
+      components/           # ConvergenceChart, ECDFChart, ViolinPlot, FitnessLandscape3D, APIDoc
+      types/benchmark.ts    # TypeScript interfaces for benchmark JSON schema
+      utils/benchmarkTransforms.ts  # Transform benchmark JSON → ECharts series
+    types/griffe.d.ts        # TypeScript types for Griffe AST output
+  api/                      # Griffe-generated JSON (*.json, gitignored output)
+  public/
+    benchmarks/             # Benchmark JSON served to the browser
+      demo-benchmark-data.json
+    optimizers/optimizers.json
+  algorithms/               # Per-algorithm markdown pages
+  benchmarks/               # Benchmark methodology docs
+  guide/                    # User guide
+
+scripts/                    # Dev tooling scripts
+  generate_docs.py          # Griffe + sidebar generation
+  unified_validator.py      # Pydantic schema validation for docstrings
+
+.github/workflows/
+  benchmark-pipeline.yml    # COCO/BBOB CI pipeline
+  benchmark-visualizations.yaml  # Weekly benchmark run + artifact upload
+  docs.yaml                 # VitePress build + GitHub Pages deploy
+```
+
+## Pre-commit Hooks
+
+Runs automatically on `git commit`:
+1. `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-added-large-files`
+2. `ruff` — lint with auto-fix
+3. `ruff-format` — format (modifies files; re-stage and commit again if it fires)
+4. `pydocstyle` — Google-style docstring compliance on `opt/` categories
+5. `google-docstring-inline-summaries` — custom script enforcing inline summaries
+6. `validate-optimizer-docstrings` — Pydantic schema validation
+
+**When ruff-format fires and fails a commit:** re-stage the modified files and commit again — it auto-fixed them.
+
+## Python Conventions
+
+- All optimizer files must have Google-style docstrings with COCO/BBOB-compliant examples
+- Doctests must not use `np.True_` — wrap boolean assertions in `bool()`
+- Use `from __future__ import annotations` (enforced by ruff isort)
+- Ruff `select = ["ALL"]` with specific ignores — see `pyproject.toml`
+- History tracking: optimizers store `self.history = {"best_fitness": [], "mean_fitness": []}` updated each iteration
+
+## VitePress / TypeScript Conventions
+
+### SSR Safety (critical)
+ECharts accesses `document` at module load time — it CANNOT be statically imported in `theme/index.ts`.
+Chart components (ConvergenceChart, ECDFChart, ViolinPlot, FitnessLandscape3D) **must** be registered via `defineAsyncComponent` inside a `typeof window !== 'undefined'` guard:
+
+```typescript
+// theme/index.ts — correct pattern
+if (typeof window !== 'undefined') {
+  app.component('ConvergenceChart', defineAsyncComponent(() =>
+    import('./components/ConvergenceChart.vue')
+  ))
+}
+```
+
+Always wrap chart components in `<ClientOnly>` in markdown.
+
+### Benchmark Data Flow
+```
+benchmarks/run_benchmark_suite.py
+  → benchmarks/output/results.json      (CI artifact)
+  → docs/public/benchmarks/*.json       (served to browser)
+      ↓
+  benchmarkTransforms.ts                (buildConvergenceSeries / buildECDFSeries / buildViolinSeries)
+      ↓
+  ConvergenceChart / ECDFChart / ViolinPlot (ECharts, Catppuccin Mocha theme)
+```
+
+### API Documentation Flow
+```
+opt/ (Python source)
+  → griffe dump → docs/api/*.json
+      ↓
+  docs/.vitepress/loaders/api.data.ts   (VitePress data loader)
+      ↓
+  APIDoc.vue (rendered on algorithm pages)
+```
+
+## GitHub / git
+
+- **Main branch**: `main`
+- **Active dev branch**: `finishing-version-020-2` (ahead of main — all Phase 4-5 doc work lives here)
+- **Active epic**: Issue #52 — VitePress Documentation Site with Scientific Visualization Suite
+
+### gh CLI
+Must unset the environment token before use:
+```bash
+unset GITHUB_TOKEN && gh issue view 52 --repo Anselmoo/useful-optimizer
+```
+Alternatively use the `mcp__github__*` MCP tools which bypass this conflict.
+
+## Open Work (Epic #52)
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| #134 | Wire ECharts to real benchmark data | ✅ Done (commit d141809) |
+| #92 | package-lock.json for npm CI | Open PR |
+| #86 | CI/CD & GitHub Pages deployment | Waiting |
+| #55 | Zensical alternative (alternative doc stack) | Parked |

--- a/benchmarks/generate_plots.py
+++ b/benchmarks/generate_plots.py
@@ -64,8 +64,10 @@ def plot_convergence_curves(
         if optimizer_data.get("runs"):
             # Get the first successful run with convergence history
             for run in optimizer_data["runs"]:
-                if run["status"] == "success" and run.get("convergence_history"):
-                    history = run.get("convergence_history", [])
+                if run["status"] == "success" and run.get("history", {}).get(
+                    "best_fitness"
+                ):
+                    history = run.get("history", {}).get("best_fitness", [])
                     ax.plot(history, label=optimizer_name, linewidth=2, alpha=0.8)
                     break
 

--- a/docs/.vitepress/theme/components/BenchmarkCharts.vue
+++ b/docs/.vitepress/theme/components/BenchmarkCharts.vue
@@ -1,0 +1,244 @@
+<script setup lang="ts">
+/**
+ * Unified benchmark chart wrapper. Loads data and renders convergence,
+ * violin, and ECDF charts for a given algorithm/function/dimension.
+ *
+ * Usage:
+ *   <BenchmarkCharts algorithm="ParticleSwarm" functionName="shifted_ackley" :dimension="2" />
+ */
+import { ref, computed, onMounted, watch } from 'vue'
+import ConvergenceChart from './ConvergenceChart.vue'
+import ECDFChart from './ECDFChart.vue'
+import ViolinPlot from './ViolinPlot.vue'
+
+interface Props {
+  algorithm: string
+  functionName: string
+  dimension?: number
+  showConvergence?: boolean
+  showECDF?: boolean
+  showViolin?: boolean
+  targetPrecisions?: number[]
+  compareWith?: string[]
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  dimension: 2,
+  showConvergence: true,
+  showECDF: true,
+  showViolin: true,
+  targetPrecisions: () => [1e-1, 1e-3, 1e-5, 1e-7]
+})
+
+const benchmarkData = ref<any>(null)
+const loading = ref(true)
+const error = ref<string | null>(null)
+
+const loadData = async () => {
+  try {
+    loading.value = true
+    error.value = null
+
+    let response = await fetch('/benchmarks/benchmark-results.json')
+    if (!response.ok) {
+      response = await fetch('/benchmarks/demo-benchmark-data.json')
+      if (!response.ok) throw new Error('Failed to load benchmark data')
+    }
+
+    const data = await response.json()
+    const funcData = data.benchmarks[props.functionName]?.[props.dimension.toString()]
+    if (!funcData) {
+      throw new Error(`No data for ${props.functionName} dimension ${props.dimension}`)
+    }
+
+    const algorithms = [props.algorithm, ...(props.compareWith ?? [])]
+    const filtered: Record<string, any> = {}
+    for (const alg of algorithms) {
+      if (funcData[alg]) filtered[alg] = funcData[alg]
+    }
+    if (Object.keys(filtered).length === 0) {
+      throw new Error(`No data for algorithm(s): ${algorithms.join(', ')}`)
+    }
+    benchmarkData.value = filtered
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Unknown error'
+  } finally {
+    loading.value = false
+  }
+}
+
+const convergenceData = computed(() => {
+  if (!benchmarkData.value) return []
+  return Object.entries(benchmarkData.value).map(([name, bench]: [string, any]) => {
+    const runs = bench.runs.filter((run: any) => run.history?.best_fitness?.length)
+    if (runs.length === 0) return null
+    const allHistories: number[][] = runs.map((run: any) => run.history.best_fitness)
+    const maxLength = Math.max(...allHistories.map(h => h.length))
+    const iterations: number[] = []
+    const meanArr: number[] = []
+    const stdArr: number[] = []
+    for (let i = 0; i < maxLength; i++) {
+      const values = allHistories.filter(h => i < h.length).map(h => h[i])
+      if (values.length === 0) continue
+      const mu = values.reduce((a, b) => a + b, 0) / values.length
+      iterations.push(i)
+      meanArr.push(mu)
+      stdArr.push(
+        values.length > 1
+          ? Math.sqrt(values.map(v => (v - mu) ** 2).reduce((a, b) => a + b, 0) / values.length)
+          : 0
+      )
+    }
+    return { algorithm: name, iterations, mean: meanArr, std: stdArr }
+  }).filter(Boolean)
+})
+
+const violinData = computed(() => {
+  if (!benchmarkData.value) return []
+  return Object.entries(benchmarkData.value).map(([name, bench]: [string, any]) => ({
+    algorithm: name,
+    values: bench.runs.map((run: any) => run.best_fitness)
+  }))
+})
+
+const ecdfData = computed(() => {
+  if (!benchmarkData.value) return []
+  return Object.entries(benchmarkData.value).map(([name, bench]: [string, any]) => {
+    const runs = bench.runs.filter((run: any) => run.history?.best_fitness?.length)
+    if (runs.length === 0) return null
+    const maxEvals = Math.max(...runs.map((r: any) => r.n_evaluations))
+    const budgetPoints = Array.from({ length: 20 }, (_, i) =>
+      Math.pow(10, Math.log10(10) + (Math.log10(maxEvals / props.dimension) - Math.log10(10)) * i / 19)
+    )
+    const budget: number[] = []
+    const proportion: number[] = []
+    for (const budgetVal of budgetPoints) {
+      const absoluteBudget = budgetVal * props.dimension
+      let totalTargetsReached = 0
+      for (const target of props.targetPrecisions) {
+        const reachedCount = runs.filter((run: any) => {
+          const history: number[] = run.history.best_fitness
+          const evalsPerIter = run.n_evaluations / history.length
+          return history.some((val, i) => (i + 1) * evalsPerIter <= absoluteBudget && val <= target)
+        }).length
+        if (reachedCount > 0) totalTargetsReached++
+      }
+      budget.push(budgetVal)
+      proportion.push(totalTargetsReached / props.targetPrecisions.length)
+    }
+    return { algorithm: name, budget, proportion }
+  }).filter(Boolean)
+})
+
+onMounted(loadData)
+watch(() => [props.algorithm, props.functionName, props.dimension, props.compareWith], loadData)
+</script>
+
+<template>
+  <div class="benchmark-charts">
+    <div v-if="loading" class="loading-state">
+      <div class="spinner"></div>
+      <p>Loading benchmark data...</p>
+    </div>
+
+    <div v-else-if="error" class="error-state">
+      <p>Failed to load benchmark data</p>
+      <p class="error-message">{{ error }}</p>
+    </div>
+
+    <div v-else class="charts-container">
+      <div v-if="showConvergence && convergenceData.length > 0" class="chart-section">
+        <h3>Convergence Analysis</h3>
+        <ConvergenceChart
+          :data="convergenceData"
+          :title="`${algorithm} on ${functionName} (${dimension}D)`"
+          xAxisLabel="Iteration"
+          yAxisLabel="Best Fitness"
+          :logScale="true"
+          :showConfidenceBand="true"
+        />
+      </div>
+
+      <div v-if="showViolin && violinData.length > 0" class="chart-section">
+        <h3>Final Fitness Distribution</h3>
+        <ViolinPlot
+          :data="violinData"
+          :title="`Distribution: ${functionName} (${dimension}D)`"
+          yAxisLabel="Best Fitness"
+          :logScale="true"
+          :showBoxplot="true"
+          :showPoints="true"
+        />
+      </div>
+
+      <div v-if="showECDF && ecdfData.length > 0" class="chart-section">
+        <h3>Performance Profile (ECDF)</h3>
+        <ECDFChart
+          :data="ecdfData"
+          :title="`ECDF: ${functionName} (${dimension}D)`"
+          xAxisLabel="log₁₀(#f-evaluations / dimension)"
+          yAxisLabel="Proportion of targets reached"
+          :logXAxis="true"
+          :targetPrecisions="targetPrecisions"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.benchmark-charts {
+  margin: 20px 0;
+}
+
+.loading-state,
+.error-state {
+  padding: 40px 20px;
+  text-align: center;
+  border-radius: 8px;
+  background-color: var(--ctp-mocha-surface0, #313244);
+}
+
+.loading-state {
+  color: var(--ctp-mocha-text, #cdd6f4);
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  margin: 0 auto 16px;
+  border: 4px solid var(--ctp-mocha-surface1, #45475a);
+  border-top-color: var(--ctp-mocha-mauve, #cba6f7);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.error-state {
+  color: var(--ctp-mocha-red, #f38ba8);
+  border: 1px solid var(--ctp-mocha-red, #f38ba8);
+}
+
+.error-message {
+  font-family: monospace;
+  font-size: 0.9rem;
+  margin-top: 8px;
+  opacity: 0.8;
+}
+
+.charts-container {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.chart-section h3 {
+  color: var(--ctp-mocha-mauve, #cba6f7);
+  margin-bottom: 16px;
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,62 +1,31 @@
-// https://vitepress.dev/guide/custom-theme
 import { h, defineAsyncComponent } from 'vue'
 import type { Theme } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
 import './style.css'
 
+// APIDoc has no browser globals — safe to register synchronously
+import APIDoc from './components/APIDoc.vue'
+
 export default {
   extends: DefaultTheme,
   Layout: () => {
-    return h(DefaultTheme.Layout, null, {
-      // https://vitepress.dev/guide/extending-default-theme#layout-slots
-    })
+    return h(DefaultTheme.Layout, null, {})
   },
   async enhanceApp({ app }) {
-    // Only register components on client side
+    app.component('APIDoc', APIDoc)
+
+    // Chart components import echarts which accesses `document` at module load
+    // time — must be deferred to client side only.
     if (typeof window !== 'undefined') {
-      // Dynamically import and register ECharts
-      const { default: VChart } = await import('vue-echarts')
-      const { use } = await import('echarts/core')
-      const { CanvasRenderer } = await import('echarts/renderers')
-      const { LineChart, ScatterChart, BoxplotChart, BarChart } = await import('echarts/charts')
-      const {
-        GridComponent,
-        TooltipComponent,
-        LegendComponent,
-        TitleComponent,
-        VisualMapComponent,
-        ToolboxComponent
-      } = await import('echarts/components')
-
-      // Register ECharts components
-      use([
-        CanvasRenderer,
-        LineChart,
-        ScatterChart,
-        BoxplotChart,
-        BarChart,
-        GridComponent,
-        TooltipComponent,
-        LegendComponent,
-        TitleComponent,
-        VisualMapComponent,
-        ToolboxComponent
-      ])
-
-      app.component('VChart', VChart)
-
-      // Register 2D chart components as async
-      app.component('ECDFChart', defineAsyncComponent(() =>
-        import('./components/ECDFChart.vue')
-      ))
       app.component('ConvergenceChart', defineAsyncComponent(() =>
         import('./components/ConvergenceChart.vue')
+      ))
+      app.component('ECDFChart', defineAsyncComponent(() =>
+        import('./components/ECDFChart.vue')
       ))
       app.component('ViolinPlot', defineAsyncComponent(() =>
         import('./components/ViolinPlot.vue')
       ))
-
-      // Register 3D components as async (client-only)
       app.component('FitnessLandscape3D', defineAsyncComponent(() =>
         import('./components/FitnessLandscape3D.vue')
       ))

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -29,6 +29,9 @@ export default {
       app.component('FitnessLandscape3D', defineAsyncComponent(() =>
         import('./components/FitnessLandscape3D.vue')
       ))
+      app.component('BenchmarkCharts', defineAsyncComponent(() =>
+        import('./components/BenchmarkCharts.vue')
+      ))
     }
   }
 } satisfies Theme

--- a/docs/.vitepress/theme/types/benchmark.ts
+++ b/docs/.vitepress/theme/types/benchmark.ts
@@ -1,5 +1,29 @@
 // Auto-generated from benchmark-data-schema.json - DO NOT EDIT
 
+export interface Benchmarks {
+  runs: {
+    best_fitness: number
+    best_solution: number[]
+    n_evaluations: number
+    history?: {
+      best_fitness?: number[]
+      mean_fitness?: number[]
+    }
+    status?: string
+    [k: string]: unknown
+  }[]
+  statistics: {
+    mean_fitness: number
+    std_fitness: number
+    min_fitness: number
+    max_fitness: number
+    median_fitness: number
+    q1_fitness?: number
+    q3_fitness?: number
+  }
+  success_rate: number
+}
+
 /**
  * IOHprofiler-compatible benchmark results for optimizer evaluation
  */

--- a/docs/.vitepress/theme/utils/benchmarkTransforms.ts
+++ b/docs/.vitepress/theme/utils/benchmarkTransforms.ts
@@ -1,0 +1,175 @@
+import type { BenchmarkDataSchema } from '../types/benchmark'
+
+type Run = BenchmarkDataSchema['benchmarks'][string][string][string]['runs'][number]
+
+export interface ConvergenceSeries {
+  algorithm: string
+  iterations: number[]
+  mean: number[]
+  std?: number[]
+}
+
+export interface ViolinSeries {
+  algorithm: string
+  values: number[]
+}
+
+export interface ECDFSeries {
+  algorithm: string
+  budget: number[]
+  proportion: number[]
+}
+
+const toDimKey = (dim: string | number) =>
+  typeof dim === 'string' ? dim : String(dim)
+
+const filterAlgorithms = (
+  optimizers: Record<string, { runs: Run[] }>,
+  algorithms?: string[]
+) => {
+  if (!algorithms || algorithms.length === 0) return optimizers
+  return Object.fromEntries(
+    Object.entries(optimizers).filter(([name]) => algorithms.includes(name))
+  )
+}
+
+const getOptimizerRuns = (
+  data: BenchmarkDataSchema | null,
+  funcName: string,
+  dim: string | number,
+  algorithms?: string[]
+): Record<string, Run[]> => {
+  if (!data?.benchmarks?.[funcName]) return {}
+  const dimKey = toDimKey(dim)
+  const funcEntry = data.benchmarks[funcName]
+  if (!funcEntry?.[dimKey]) return {}
+
+  const optimizers = filterAlgorithms(funcEntry[dimKey], algorithms)
+  return Object.fromEntries(
+    Object.entries(optimizers).map(([name, details]) => [
+      name,
+      details.runs ?? []
+    ])
+  )
+}
+
+const mean = (values: number[]) =>
+  values.reduce((sum, value) => sum + value, 0) / (values.length || 1)
+
+const stdDev = (values: number[], mu: number) => {
+  if (values.length === 0) return 0
+  const variance =
+    values.reduce((sum, value) => sum + (value - mu) ** 2, 0) / values.length
+  return Math.sqrt(variance)
+}
+
+export const buildConvergenceSeries = (
+  data: BenchmarkDataSchema | null,
+  funcName: string,
+  dim: string | number,
+  algorithms?: string[]
+): ConvergenceSeries[] => {
+  const runsByOptimizer = getOptimizerRuns(data, funcName, dim, algorithms)
+  return Object.entries(runsByOptimizer).map(([optimizer, runs]) => {
+    const histories = runs
+      .map(run => run.history?.best_fitness ?? [])
+      .filter(history => history.length > 0)
+
+    const maxLength = Math.max(0, ...histories.map(history => history.length))
+    const iterations: number[] = []
+    const means: number[] = []
+    const stds: number[] = []
+
+    for (let i = 0; i < maxLength; i += 1) {
+      const values = histories
+        .map(history => history[i])
+        .filter((value): value is number => typeof value === 'number')
+
+      if (values.length === 0) continue
+      const mu = mean(values)
+      iterations.push(i)
+      means.push(mu)
+      stds.push(stdDev(values, mu))
+    }
+
+    return {
+      algorithm: optimizer,
+      iterations,
+      mean: means,
+      std: stds.some(value => value > 0) ? stds : undefined
+    }
+  })
+}
+
+export const buildViolinSeries = (
+  data: BenchmarkDataSchema | null,
+  funcName: string,
+  dim: string | number,
+  algorithms?: string[]
+): ViolinSeries[] => {
+  const runsByOptimizer = getOptimizerRuns(data, funcName, dim, algorithms)
+  return Object.entries(runsByOptimizer).map(([optimizer, runs]) => ({
+    algorithm: optimizer,
+    values: runs
+      .map(run => run.best_fitness)
+      .filter((value): value is number => typeof value === 'number')
+  }))
+}
+
+const toNormalizedBudget = (nEvaluations: number | undefined, dim: number) => {
+  if (!nEvaluations || dim <= 0) return Number.POSITIVE_INFINITY
+  return nEvaluations / dim
+}
+
+export const buildECDFSeries = (
+  data: BenchmarkDataSchema | null,
+  funcName: string,
+  dim: string | number,
+  targets: number[],
+  algorithms?: string[]
+): ECDFSeries[] => {
+  const dimValue = typeof dim === 'string' ? Number(dim) : dim
+  const runsByOptimizer = getOptimizerRuns(data, funcName, dim, algorithms)
+
+  return Object.entries(runsByOptimizer).map(([optimizer, runs]) => {
+    const pairs = runs.flatMap(run =>
+      targets.map(target => ({
+        solved:
+          typeof run.best_fitness === 'number' &&
+          run.best_fitness <= target,
+        budget: toNormalizedBudget(run.n_evaluations, dimValue)
+      }))
+    )
+
+    const solvedBudgets = pairs
+      .filter(pair => pair.solved && Number.isFinite(pair.budget))
+      .map(pair => pair.budget)
+
+    const budgetPoints = Array.from(new Set([0, ...solvedBudgets])).sort(
+      (a, b) => a - b
+    )
+
+    const proportions = budgetPoints.map(budget => {
+      const solvedCount = pairs.filter(
+        pair => pair.solved && pair.budget <= budget
+      ).length
+      return pairs.length ? solvedCount / pairs.length : 0
+    })
+
+    return {
+      algorithm: optimizer,
+      budget: budgetPoints,
+      proportion: proportions
+    }
+  })
+}
+
+export const fetchBenchmarkData = async (
+  path: string
+): Promise<BenchmarkDataSchema> => {
+  const response = await fetch(path)
+  if (!response.ok) {
+    throw new Error(`Failed to load benchmark data from ${path}: ${response.status} ${response.statusText}`)
+  }
+  return (await response.json()) as BenchmarkDataSchema
+}

--- a/docs/.vitepress/theme/utils/useBenchmarkData.ts
+++ b/docs/.vitepress/theme/utils/useBenchmarkData.ts
@@ -1,0 +1,81 @@
+import { ref, computed } from 'vue'
+import type { BenchmarkDataSchema, Benchmarks } from '../types/benchmark'
+
+export function useBenchmarkData(
+  functionName: string,
+  dimension: number,
+  optimizers?: string[]
+) {
+  const data = ref<BenchmarkDataSchema | null>(null)
+  const loading = ref(true)
+  const error = ref<string | null>(null)
+
+  const loadData = async () => {
+    try {
+      loading.value = true
+      error.value = null
+
+      let response = await fetch('/benchmarks/benchmark-results.json')
+      if (!response.ok) {
+        response = await fetch('/benchmarks/demo-benchmark-data.json')
+        if (!response.ok) {
+          throw new Error('Failed to load benchmark data')
+        }
+      }
+      data.value = await response.json()
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Unknown error loading data'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  const filteredData = computed(() => {
+    if (!data.value) return null
+    const funcData = data.value.benchmarks[functionName]
+    if (!funcData) return null
+    const dimData = funcData[dimension.toString()]
+    if (!dimData) return null
+    if (optimizers && optimizers.length > 0) {
+      const filtered: Record<string, Benchmarks> = {}
+      for (const opt of optimizers) {
+        if (dimData[opt]) filtered[opt] = dimData[opt] as Benchmarks
+      }
+      return filtered
+    }
+    return dimData
+  })
+
+  const metadata = computed(() => data.value?.metadata ?? null)
+
+  const availableFunctions = computed(() =>
+    data.value ? Object.keys(data.value.benchmarks) : []
+  )
+
+  const availableDimensions = computed(() => {
+    if (!data.value) return []
+    const funcData = data.value.benchmarks[functionName]
+    return funcData ? Object.keys(funcData).map(Number) : []
+  })
+
+  const availableOptimizers = computed(() => {
+    if (!data.value) return []
+    const funcData = data.value.benchmarks[functionName]
+    if (!funcData) return []
+    const dimData = funcData[dimension.toString()]
+    return dimData ? Object.keys(dimData) : []
+  })
+
+  loadData()
+
+  return {
+    data: filteredData,
+    metadata,
+    loading,
+    error,
+    availableFunctions,
+    availableDimensions,
+    availableOptimizers,
+    reload: loadData
+  }
+}

--- a/docs/benchmark-demo.md
+++ b/docs/benchmark-demo.md
@@ -1,174 +1,85 @@
 # Benchmark Visualization Demo
 
-This page demonstrates the chart components using real mock benchmark data that validates against the schema.
+This page demonstrates the chart components using real benchmark JSON data loaded at runtime.
 
-<script setup>
-import { computed, ref, onMounted } from 'vue'
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import {
+  buildConvergenceSeries,
+  buildECDFSeries,
+  buildViolinSeries,
+  fetchBenchmarkData
+} from './.vitepress/theme/utils/benchmarkTransforms'
+import type { BenchmarkDataSchema } from './.vitepress/theme/types/benchmark'
 
-// Mock data structure - in production, this would be fetched from the API
-const mockData = ref({
-  metadata: {
-    max_iterations: 100,
-    n_runs: 10,
-    dimensions: [2, 5, 10],
-    timestamp: "2024-12-24T15:45:00Z",
-    python_version: "3.12.3",
-    numpy_version: "1.26.4"
-  },
-  benchmarks: {
-    shifted_ackley: {
-      "2": {
-        ParticleSwarm: {
-          runs: [
-            {
-              best_fitness: 0.0012345,
-              best_solution: [0.001, -0.002],
-              n_evaluations: 2000,
-              history: {
-                best_fitness: [10.5, 5.2, 2.1, 0.8, 0.3, 0.1, 0.05, 0.02, 0.01, 0.0012345],
-                mean_fitness: [15.3, 8.7, 4.5, 2.3, 1.2, 0.6, 0.3, 0.15, 0.08, 0.04]
-              }
-            },
-            {
-              best_fitness: 0.0023456,
-              best_solution: [-0.001, 0.003],
-              n_evaluations: 2000,
-              history: {
-                best_fitness: [11.2, 6.1, 2.8, 1.1, 0.5, 0.2, 0.08, 0.04, 0.015, 0.0023456],
-                mean_fitness: [16.1, 9.2, 5.1, 2.8, 1.5, 0.8, 0.4, 0.2, 0.1, 0.05]
-              }
-            },
-            {
-              best_fitness: 0.0018765,
-              best_solution: [0.002, 0.001],
-              n_evaluations: 2000,
-              history: {
-                best_fitness: [10.8, 5.8, 2.5, 0.9, 0.4, 0.15, 0.06, 0.03, 0.012, 0.0018765],
-                mean_fitness: [15.8, 8.9, 4.8, 2.5, 1.3, 0.7, 0.35, 0.18, 0.09, 0.045]
-              }
-            }
-          ],
-          statistics: {
-            mean_fitness: 0.0018189,
-            std_fitness: 0.0004681,
-            min_fitness: 0.0012345,
-            max_fitness: 0.0023456,
-            median_fitness: 0.0018765,
-            q1_fitness: 0.0015555,
-            q3_fitness: 0.0021111
-          },
-          success_rate: 1.0
-        },
-        DifferentialEvolution: {
-          runs: [
-            {
-              best_fitness: 0.0009876,
-              best_solution: [0.0005, -0.0008],
-              n_evaluations: 2000,
-              history: {
-                best_fitness: [12.3, 6.5, 3.2, 1.5, 0.7, 0.3, 0.12, 0.05, 0.02, 0.0009876],
-                mean_fitness: [17.2, 10.1, 5.8, 3.1, 1.8, 0.9, 0.45, 0.22, 0.11, 0.055]
-              }
-            },
-            {
-              best_fitness: 0.0015432,
-              best_solution: [-0.0007, 0.0009],
-              n_evaluations: 2000,
-              history: {
-                best_fitness: [11.8, 6.2, 2.9, 1.3, 0.6, 0.25, 0.1, 0.045, 0.018, 0.0015432],
-                mean_fitness: [16.5, 9.5, 5.3, 2.9, 1.6, 0.85, 0.42, 0.21, 0.105, 0.052]
-              }
-            },
-            {
-              best_fitness: 0.0011234,
-              best_solution: [0.0003, 0.0005],
-              n_evaluations: 2000,
-              history: {
-                best_fitness: [12.0, 6.3, 3.0, 1.4, 0.65, 0.28, 0.11, 0.048, 0.019, 0.0011234],
-                mean_fitness: [16.8, 9.8, 5.5, 3.0, 1.7, 0.88, 0.43, 0.215, 0.108, 0.054]
-              }
-            }
-          ],
-          statistics: {
-            mean_fitness: 0.0012181,
-            std_fitness: 0.0002379,
-            min_fitness: 0.0009876,
-            max_fitness: 0.0015432,
-            median_fitness: 0.0011234,
-            q1_fitness: 0.0010555,
-            q3_fitness: 0.0013333
-          },
-          success_rate: 1.0
-        }
-      }
-    }
+const datasetPath = '/benchmarks/demo-benchmark-data.json'
+const funcName = 'shifted_ackley'
+const dimension = 2
+const ecdfTargets = [1e-1, 1e-3, 1e-5, 1e-7]
+
+const dataset = ref<BenchmarkDataSchema | null>(null)
+const loading = ref(true)
+const error = ref<string | null>(null)
+
+onMounted(async () => {
+  try {
+    dataset.value = await fetchBenchmarkData(datasetPath)
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to load benchmark data'
+  } finally {
+    loading.value = false
   }
 })
 
-// Extract shifted_ackley data for dimension 2
-const ackleyData = computed(() => mockData.value.benchmarks.shifted_ackley['2'])
+const ackleyData = computed(
+  () => dataset.value?.benchmarks?.[funcName]?.[String(dimension)] ?? {}
+)
 const optimizers = computed(() => Object.keys(ackleyData.value))
 
-// Transform data for ConvergenceChart
-const convergenceData = computed(() => {
-  return optimizers.value.map(opt => {
-    const firstRun = ackleyData.value[opt].runs[0]
-    return {
-      algorithm: opt,
-      iterations: Array.from({length: firstRun.history.best_fitness.length}, (_, i) => i * 10),
-      mean: firstRun.history.best_fitness,
-      std: firstRun.history.mean_fitness.map((m, i) => Math.abs(m - firstRun.history.best_fitness[i]))
-    }
-  })
-})
+const convergenceData = computed(() =>
+  buildConvergenceSeries(dataset.value, funcName, dimension, optimizers.value)
+)
 
-// Transform data for ViolinPlot
-const violinData = computed(() => {
-  return optimizers.value.map(opt => ({
-    algorithm: opt,
-    values: ackleyData.value[opt].runs.map(run => run.best_fitness)
-  }))
-})
+const violinData = computed(() =>
+  buildViolinSeries(dataset.value, funcName, dimension, optimizers.value)
+)
 
-// Transform data for ECDF
-const ecdfData = computed(() => {
-  return optimizers.value.map(opt => {
-    const runs = ackleyData.value[opt].runs
-    const fitnessValues = runs.map(r => r.best_fitness).sort((a, b) => a - b)
-    const budgets = [100, 500, 1000, 1500, 2000]
-    const proportions = budgets.map(budget => {
-      // Simulate proportion based on fitness threshold
-      const threshold = 0.01 / (budget / 2000)
-      return fitnessValues.filter(f => f <= threshold).length / fitnessValues.length
-    })
+const ecdfData = computed(() =>
+  buildECDFSeries(dataset.value, funcName, dimension, ecdfTargets, optimizers.value)
+)
 
-    return {
-      algorithm: opt,
-      budget: budgets,
-      proportion: proportions
-    }
-  })
-})
-
-// Metadata display
-const metadata = computed(() => mockData.value.metadata)
+const metadata = computed(() => dataset.value?.metadata)
+const hasData = computed(() => optimizers.value.length > 0)
 </script>
+
+<div v-if="error" class="warning custom-block">
+  <p class="custom-block-title">Error loading benchmark data</p>
+  <p>{{ error }}</p>
+</div>
+<div v-else-if="loading">
+  Loading benchmark data from <code>{{ datasetPath }}</code>…
+</div>
+<div v-else-if="!hasData">
+  No benchmark runs found for <strong>{{ funcName }}</strong> ({{ dimension }}D).
+</div>
+
+<div v-else>
 
 ## Dataset Information
 
 **Benchmark Suite Metadata:**
-- **Max Iterations:** {{ metadata.max_iterations }}
-- **Number of Runs:** {{ metadata.n_runs }}
-- **Dimensions:** {{ metadata.dimensions.join(', ') }}
-- **Python Version:** {{ metadata.python_version }}
-- **NumPy Version:** {{ metadata.numpy_version }}
-- **Timestamp:** {{ metadata.timestamp }}
+- **Max Iterations:** {{ metadata?.max_iterations ?? '—' }}
+- **Number of Runs:** {{ metadata?.n_runs ?? '—' }}
+- **Dimensions:** {{ metadata?.dimensions?.join(', ') ?? '—' }}
+- **Python Version:** {{ metadata?.python_version ?? '—' }}
+- **NumPy Version:** {{ metadata?.numpy_version ?? '—' }}
+- **Timestamp:** {{ metadata?.timestamp ?? '—' }}
 
 ---
 
 ## Convergence Analysis
 
-Comparison of **{{ optimizers.join(' vs ') }}** on the **Shifted Ackley** function (dimension 2):
+Comparison of **{{ optimizers.join(' vs ') }}** on the **Shifted Ackley** function (dimension {{ dimension }}D):
 
 <ClientOnly>
 <ConvergenceChart
@@ -208,9 +119,10 @@ Empirical Cumulative Distribution Function showing the proportion of targets rea
 <ECDFChart
   :data="ecdfData"
   title="ECDF: Shifted Ackley (2D)"
-  xAxisLabel="Budget (function evaluations)"
+  xAxisLabel="Budget (function evaluations / dimension)"
   yAxisLabel="Proportion of targets reached"
   :logXAxis="false"
+  :targetPrecisions="ecdfTargets"
 />
 </ClientOnly>
 
@@ -265,6 +177,8 @@ Interactive 3D visualization of the Ackley function:
       </div>
     </div>
   </div>
+</div>
+
 </div>
 
 <style scoped>

--- a/docs/public/benchmarks/demo-benchmark-data.json
+++ b/docs/public/benchmarks/demo-benchmark-data.json
@@ -1,0 +1,341 @@
+{
+  "metadata": {
+    "max_iterations": 100,
+    "n_runs": 10,
+    "dimensions": [2, 5, 10],
+    "timestamp": "2026-01-05T00:00:00Z",
+    "python_version": "3.12.3",
+    "numpy_version": "2.0.0"
+  },
+  "benchmarks": {
+    "shifted_ackley": {
+      "2": {
+        "ParticleSwarm": {
+          "runs": [
+            {
+              "best_fitness": 0.0012345,
+              "best_solution": [0.001, -0.002],
+              "n_evaluations": 2000,
+              "history": {
+                "best_fitness": [10.5, 5.2, 2.1, 0.8, 0.3, 0.1, 0.05, 0.02, 0.01, 0.0012345],
+                "mean_fitness": [15.3, 8.7, 4.5, 2.3, 1.2, 0.6, 0.3, 0.15, 0.08, 0.04]
+              }
+            },
+            {
+              "best_fitness": 0.0023456,
+              "best_solution": [-0.001, 0.003],
+              "n_evaluations": 2000,
+              "history": {
+                "best_fitness": [11.2, 6.1, 2.8, 1.1, 0.5, 0.2, 0.08, 0.04, 0.015, 0.0023456],
+                "mean_fitness": [16.1, 9.2, 5.1, 2.8, 1.5, 0.8, 0.4, 0.2, 0.1, 0.05]
+              }
+            },
+            {
+              "best_fitness": 0.0018765,
+              "best_solution": [0.002, 0.001],
+              "n_evaluations": 2000,
+              "history": {
+                "best_fitness": [10.8, 5.8, 2.5, 0.9, 0.4, 0.15, 0.06, 0.03, 0.012, 0.0018765],
+                "mean_fitness": [15.8, 8.9, 4.8, 2.5, 1.3, 0.7, 0.35, 0.18, 0.09, 0.045]
+              }
+            }
+          ],
+          "statistics": {
+            "mean_fitness": 0.0018189,
+            "std_fitness": 0.0004681,
+            "min_fitness": 0.0012345,
+            "max_fitness": 0.0023456,
+            "median_fitness": 0.0018765,
+            "q1_fitness": 0.0015555,
+            "q3_fitness": 0.0021111
+          },
+          "success_rate": 1.0
+        },
+        "DifferentialEvolution": {
+          "runs": [
+            {
+              "best_fitness": 0.0009876,
+              "best_solution": [0.0005, -0.0008],
+              "n_evaluations": 2000,
+              "history": {
+                "best_fitness": [12.3, 6.5, 3.2, 1.5, 0.7, 0.3, 0.12, 0.05, 0.02, 0.0009876],
+                "mean_fitness": [17.2, 10.1, 5.8, 3.1, 1.8, 0.9, 0.45, 0.22, 0.11, 0.055]
+              }
+            },
+            {
+              "best_fitness": 0.0015432,
+              "best_solution": [-0.0007, 0.0009],
+              "n_evaluations": 2000,
+              "history": {
+                "best_fitness": [11.8, 6.2, 2.9, 1.3, 0.6, 0.25, 0.1, 0.045, 0.018, 0.0015432],
+                "mean_fitness": [16.5, 9.5, 5.3, 2.9, 1.6, 0.85, 0.42, 0.21, 0.105, 0.052]
+              }
+            },
+            {
+              "best_fitness": 0.0011234,
+              "best_solution": [0.0003, 0.0005],
+              "n_evaluations": 2000,
+              "history": {
+                "best_fitness": [12.0, 6.3, 3.0, 1.4, 0.65, 0.28, 0.11, 0.048, 0.019, 0.0011234],
+                "mean_fitness": [16.8, 9.8, 5.5, 3.0, 1.7, 0.88, 0.43, 0.215, 0.108, 0.054]
+              }
+            }
+          ],
+          "statistics": {
+            "mean_fitness": 0.0012181,
+            "std_fitness": 0.0002379,
+            "min_fitness": 0.0009876,
+            "max_fitness": 0.0015432,
+            "median_fitness": 0.0011234,
+            "q1_fitness": 0.0010555,
+            "q3_fitness": 0.0013333
+          },
+          "success_rate": 1.0
+        },
+        "SocialGroupOptimizer": {
+          "runs": [
+            {
+              "best_fitness": 0.0008543,
+              "best_solution": [0.0003, -0.0006],
+              "n_evaluations": 2000,
+              "history": {
+                "best_fitness": [13.1, 7.2, 3.8, 1.8, 0.8, 0.35, 0.14, 0.06, 0.022, 0.0008543],
+                "mean_fitness": [18.5, 11.2, 6.5, 3.5, 2.0, 1.05, 0.52, 0.26, 0.13, 0.065]
+              }
+            },
+            {
+              "best_fitness": 0.0013210,
+              "best_solution": [-0.0009, 0.0004],
+              "n_evaluations": 2000,
+              "history": {
+                "best_fitness": [12.5, 6.8, 3.5, 1.6, 0.75, 0.32, 0.13, 0.055, 0.021, 0.001321],
+                "mean_fitness": [17.8, 10.5, 6.1, 3.2, 1.85, 0.98, 0.49, 0.245, 0.122, 0.061]
+              }
+            },
+            {
+              "best_fitness": 0.0010987,
+              "best_solution": [0.0006, 0.0002],
+              "n_evaluations": 2000,
+              "history": {
+                "best_fitness": [12.8, 7.0, 3.6, 1.7, 0.78, 0.33, 0.135, 0.057, 0.0215, 0.0010987],
+                "mean_fitness": [18.1, 10.8, 6.3, 3.35, 1.92, 1.01, 0.505, 0.252, 0.126, 0.063]
+              }
+            }
+          ],
+          "statistics": {
+            "mean_fitness": 0.0010913,
+            "std_fitness": 0.0002337,
+            "min_fitness": 0.0008543,
+            "max_fitness": 0.0013210,
+            "median_fitness": 0.0010987,
+            "q1_fitness": 0.0009765,
+            "q3_fitness": 0.0012099
+          },
+          "success_rate": 1.0
+        }
+      },
+      "5": {
+        "ParticleSwarm": {
+          "runs": [
+            {
+              "best_fitness": 0.0456789,
+              "best_solution": [0.001, -0.002, 0.003, -0.001, 0.002],
+              "n_evaluations": 5000,
+              "history": {
+                "best_fitness": [25.3, 15.2, 8.5, 4.2, 2.1, 1.0, 0.5, 0.2, 0.1, 0.0456789],
+                "mean_fitness": [32.1, 20.5, 12.3, 6.8, 3.5, 1.8, 0.9, 0.45, 0.22, 0.11]
+              }
+            },
+            {
+              "best_fitness": 0.0523456,
+              "best_solution": [-0.002, 0.001, -0.003, 0.002, -0.001],
+              "n_evaluations": 5000,
+              "history": {
+                "best_fitness": [26.1, 16.0, 9.2, 4.8, 2.5, 1.2, 0.6, 0.25, 0.12, 0.0523456],
+                "mean_fitness": [33.5, 21.3, 13.1, 7.2, 3.8, 2.0, 1.0, 0.5, 0.25, 0.125]
+              }
+            }
+          ],
+          "statistics": {
+            "mean_fitness": 0.0490123,
+            "std_fitness": 0.0033334,
+            "min_fitness": 0.0456789,
+            "max_fitness": 0.0523456,
+            "median_fitness": 0.0490123,
+            "q1_fitness": 0.0473456,
+            "q3_fitness": 0.0506790
+          },
+          "success_rate": 0.95
+        },
+        "DifferentialEvolution": {
+          "runs": [
+            {
+              "best_fitness": 0.0312456,
+              "best_solution": [0.001, -0.002, 0.003, -0.001, 0.002],
+              "n_evaluations": 5000,
+              "history": {
+                "best_fitness": [24.8, 14.5, 7.8, 3.8, 1.8, 0.85, 0.42, 0.18, 0.082, 0.0312456],
+                "mean_fitness": [31.2, 19.8, 11.5, 6.2, 3.1, 1.6, 0.8, 0.4, 0.2, 0.1]
+              }
+            },
+            {
+              "best_fitness": 0.0389234,
+              "best_solution": [-0.001, 0.003, -0.002, 0.001, -0.003],
+              "n_evaluations": 5000,
+              "history": {
+                "best_fitness": [25.5, 15.1, 8.2, 4.1, 2.0, 0.95, 0.47, 0.20, 0.091, 0.0389234],
+                "mean_fitness": [32.3, 20.2, 12.0, 6.5, 3.3, 1.7, 0.85, 0.42, 0.21, 0.105]
+              }
+            }
+          ],
+          "statistics": {
+            "mean_fitness": 0.0350845,
+            "std_fitness": 0.0038389,
+            "min_fitness": 0.0312456,
+            "max_fitness": 0.0389234,
+            "median_fitness": 0.0350845,
+            "q1_fitness": 0.0331651,
+            "q3_fitness": 0.0370040
+          },
+          "success_rate": 0.98
+        }
+      }
+    },
+    "rosenbrock": {
+      "2": {
+        "ParticleSwarm": {
+          "runs": [
+            {
+              "best_fitness": 0.234567,
+              "best_solution": [0.98, 0.96],
+              "n_evaluations": 2000,
+              "history": {
+                "best_fitness": [1500.5, 850.2, 450.1, 200.5, 85.3, 35.2, 15.8, 5.6, 1.2, 0.234567],
+                "mean_fitness": [2100.3, 1200.8, 650.5, 320.2, 140.6, 60.8, 28.5, 12.3, 4.5, 1.8]
+              }
+            },
+            {
+              "best_fitness": 0.345678,
+              "best_solution": [0.97, 0.94],
+              "n_evaluations": 2000,
+              "history": {
+                "best_fitness": [1600.2, 900.5, 480.3, 220.8, 95.6, 40.2, 18.5, 6.8, 1.5, 0.345678],
+                "mean_fitness": [2200.5, 1300.2, 700.8, 350.5, 155.3, 68.5, 32.2, 14.8, 5.5, 2.2]
+              }
+            }
+          ],
+          "statistics": {
+            "mean_fitness": 0.290123,
+            "std_fitness": 0.055556,
+            "min_fitness": 0.234567,
+            "max_fitness": 0.345678,
+            "median_fitness": 0.290123,
+            "q1_fitness": 0.262345,
+            "q3_fitness": 0.317901
+          },
+          "success_rate": 0.85
+        },
+        "DifferentialEvolution": {
+          "runs": [
+            {
+              "best_fitness": 0.123456,
+              "best_solution": [0.99, 0.98],
+              "n_evaluations": 2000,
+              "history": {
+                "best_fitness": [1450.2, 800.1, 420.5, 185.3, 78.2, 30.5, 13.2, 4.8, 0.9, 0.123456],
+                "mean_fitness": [2050.5, 1150.3, 620.8, 305.1, 132.5, 55.2, 25.8, 10.9, 3.8, 1.5]
+              }
+            },
+            {
+              "best_fitness": 0.198765,
+              "best_solution": [0.99, 0.97],
+              "n_evaluations": 2000,
+              "history": {
+                "best_fitness": [1520.8, 830.5, 440.2, 195.6, 82.5, 33.2, 14.5, 5.2, 1.05, 0.198765],
+                "mean_fitness": [2120.2, 1220.6, 660.5, 325.8, 142.3, 58.8, 27.2, 11.8, 4.1, 1.65]
+              }
+            }
+          ],
+          "statistics": {
+            "mean_fitness": 0.161111,
+            "std_fitness": 0.037655,
+            "min_fitness": 0.123456,
+            "max_fitness": 0.198765,
+            "median_fitness": 0.161111,
+            "q1_fitness": 0.142284,
+            "q3_fitness": 0.179938
+          },
+          "success_rate": 0.92
+        }
+      }
+    },
+    "sphere": {
+      "2": {
+        "ParticleSwarm": {
+          "runs": [
+            {
+              "best_fitness": 0.00012345,
+              "best_solution": [0.0001, -0.0002],
+              "n_evaluations": 1000,
+              "history": {
+                "best_fitness": [5.5, 2.8, 1.2, 0.5, 0.2, 0.08, 0.03, 0.01, 0.003, 0.00012345],
+                "mean_fitness": [8.2, 4.5, 2.3, 1.1, 0.5, 0.22, 0.1, 0.045, 0.02, 0.008]
+              }
+            },
+            {
+              "best_fitness": 0.00009876,
+              "best_solution": [-0.0001, 0.0001],
+              "n_evaluations": 1000,
+              "history": {
+                "best_fitness": [5.2, 2.6, 1.1, 0.45, 0.18, 0.075, 0.028, 0.009, 0.0028, 0.00009876],
+                "mean_fitness": [7.8, 4.2, 2.1, 1.0, 0.46, 0.20, 0.09, 0.042, 0.018, 0.007]
+              }
+            }
+          ],
+          "statistics": {
+            "mean_fitness": 0.000111105,
+            "std_fitness": 0.000012345,
+            "min_fitness": 0.00009876,
+            "max_fitness": 0.00012345,
+            "median_fitness": 0.000111105,
+            "q1_fitness": 0.000105033,
+            "q3_fitness": 0.000117178
+          },
+          "success_rate": 1.0
+        },
+        "DifferentialEvolution": {
+          "runs": [
+            {
+              "best_fitness": 0.00008765,
+              "best_solution": [0.00005, -0.00007],
+              "n_evaluations": 1000,
+              "history": {
+                "best_fitness": [6.2, 3.1, 1.5, 0.7, 0.3, 0.12, 0.05, 0.02, 0.005, 0.00008765],
+                "mean_fitness": [9.3, 5.2, 2.8, 1.4, 0.7, 0.35, 0.17, 0.08, 0.035, 0.015]
+              }
+            },
+            {
+              "best_fitness": 0.00007654,
+              "best_solution": [-0.00006, 0.00004],
+              "n_evaluations": 1000,
+              "history": {
+                "best_fitness": [5.9, 2.95, 1.42, 0.66, 0.285, 0.114, 0.047, 0.019, 0.0048, 0.00007654],
+                "mean_fitness": [8.85, 4.95, 2.66, 1.33, 0.665, 0.332, 0.161, 0.076, 0.033, 0.014]
+              }
+            }
+          ],
+          "statistics": {
+            "mean_fitness": 0.000082095,
+            "std_fitness": 0.000005555,
+            "min_fitness": 0.00007654,
+            "max_fitness": 0.00008765,
+            "median_fitness": 0.000082095,
+            "q1_fitness": 0.000079318,
+            "q3_fitness": 0.000084873
+          },
+          "success_rate": 1.0
+        }
+      }
+    }
+  }
+}

--- a/docs/test-charts.md
+++ b/docs/test-charts.md
@@ -1,68 +1,102 @@
 # Chart Components Test
 
-This page demonstrates the ECharts and TresJS visualization components.
+This page demonstrates the ECharts and TresJS visualization components using real benchmark JSON data.
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import {
+  buildConvergenceSeries,
+  buildECDFSeries,
+  buildViolinSeries,
+  fetchBenchmarkData
+} from './.vitepress/theme/utils/benchmarkTransforms'
+import type { BenchmarkDataSchema } from './.vitepress/theme/types/benchmark'
+
+const datasetPath = '/benchmarks/demo-benchmark-data.json'
+const funcName = 'shifted_ackley'
+const dimension = 2
+const ecdfTargets = [1e-1, 1e-3, 1e-5, 1e-7]
+
+const dataset = ref<BenchmarkDataSchema | null>(null)
+const loading = ref(true)
+const error = ref<string | null>(null)
+
+onMounted(async () => {
+  try {
+    dataset.value = await fetchBenchmarkData(datasetPath)
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to load benchmark data'
+  } finally {
+    loading.value = false
+  }
+})
+
+const optimizers = computed(() => {
+  const slice = dataset.value?.benchmarks?.[funcName]?.[String(dimension)]
+  return slice ? Object.keys(slice) : []
+})
+
+const convergenceData = computed(() =>
+  buildConvergenceSeries(dataset.value, funcName, dimension, optimizers.value)
+)
+
+const violinData = computed(() =>
+  buildViolinSeries(dataset.value, funcName, dimension, optimizers.value)
+)
+
+const ecdfData = computed(() =>
+  buildECDFSeries(dataset.value, funcName, dimension, ecdfTargets, optimizers.value)
+)
+
+const ready = computed(
+  () => !loading.value && !error.value && convergenceData.value.length > 0
+)
+</script>
 
 ## 2D Charts
+
+<div v-if="error" class="warning custom-block">
+  <p class="custom-block-title">Error</p>
+  <p>{{ error }}</p>
+</div>
+<div v-else-if="loading">
+  Loading benchmark data from <code>{{ datasetPath }}</code>…
+</div>
+<div v-else-if="!ready">
+  Benchmark data loaded, but no runs found for <strong>{{ funcName }}</strong> ({{ dimension }}D).
+</div>
+<div v-else>
 
 ### ECDF Chart
 
 <ClientOnly>
-<ECDFChart
-  :data="[
-    {
-      algorithm: 'PSO',
-      budget: [1, 10, 100, 1000, 10000],
-      proportion: [0.1, 0.3, 0.6, 0.8, 0.95]
-    },
-    {
-      algorithm: 'DE',
-      budget: [1, 10, 100, 1000, 10000],
-      proportion: [0.05, 0.2, 0.5, 0.75, 0.9]
-    }
-  ]"
-  title="ECDF: Algorithm Comparison"
-/>
+  <ECDFChart
+    :data="ecdfData"
+    title="ECDF: Algorithm Comparison"
+    :logXAxis="false"
+    :targetPrecisions="ecdfTargets"
+  />
 </ClientOnly>
 
 ### Convergence Chart
 
 <ClientOnly>
-<ConvergenceChart
-  :data="[
-    {
-      algorithm: 'PSO',
-      iterations: [0, 10, 20, 30, 40, 50],
-      mean: [100, 50, 25, 12.5, 6.25, 3.125],
-      std: [10, 8, 6, 4, 2, 1]
-    },
-    {
-      algorithm: 'DE',
-      iterations: [0, 10, 20, 30, 40, 50],
-      mean: [100, 45, 20, 9, 4, 2],
-      std: [12, 9, 7, 5, 3, 1.5]
-    }
-  ]"
-  title="Convergence Comparison"
-/>
+  <ConvergenceChart
+    :data="convergenceData"
+    title="Convergence Comparison"
+  />
 </ClientOnly>
 
 ### Violin Plot
 
 <ClientOnly>
-<ViolinPlot
-  :data="[
-    {
-      algorithm: 'PSO',
-      values: [1.5, 2.3, 1.8, 2.1, 1.9, 2.0, 1.7, 2.2, 1.6, 2.4]
-    },
-    {
-      algorithm: 'DE',
-      values: [2.1, 2.8, 2.3, 2.6, 2.4, 2.5, 2.2, 2.7, 2.0, 2.9]
-    }
-  ]"
-  title="Final Fitness Distribution"
-/>
+  <ViolinPlot
+    :data="violinData"
+    title="Final Fitness Distribution"
+  />
 </ClientOnly>
+
+</div>
 
 ## 3D Visualization
 
@@ -77,7 +111,3 @@ This page demonstrates the ECharts and TresJS visualization components.
   colorScale="viridis"
 />
 </ClientOnly>
-
-<script setup>
-// Components are auto-registered in theme
-</script>


### PR DESCRIPTION
## Summary

Completes Epic #52 Phase 4/5 work — all VitePress chart components now load from real benchmark JSON, the Griffe API loader is wired to `APIDoc.vue`, and the documentation site is ready for GitHub Pages deployment.

### What's in this branch

**Benchmark data layer** (`d141809`, closes #134)
- `docs/.vitepress/theme/utils/benchmarkTransforms.ts` — transforms benchmark JSON → ECharts-ready series (convergence, violin, ECDF)
- `docs/public/benchmarks/demo-benchmark-data.json` — seed data (PSO/DE/SGO × ackley/rosenbrock/sphere × 2D/5D) used as fallback when CI hasn't run yet
- `docs/benchmark-demo.md` and `docs/test-charts.md` — replaced inline mock data with `fetchBenchmarkData()` + transform calls; loading/error/empty states included
- Fixed `.gitignore` — replaced blanket `docs/.vitepress/` exclusion with targeted `dist/` and `cache/` entries so theme utilities are tracked

**Griffe API → Vue data loader** (`2ab3252`, PR #137)
- `docs/.vitepress/loaders/api.data.ts` — VitePress data loader that transforms Griffe AST JSON → typed `FunctionDoc[]` for `APIDoc.vue`
- SSR-safe component registration pattern in `theme/index.ts`

**BenchmarkCharts wrapper + useBenchmarkData composable** (`138c470`, cherry-picked from #136)
- `BenchmarkCharts.vue` — declarative wrapper: `<BenchmarkCharts algorithm="PSO" functionName="shifted_ackley" :dimension="2" />`
- `useBenchmarkData.ts` — Vue composable with reactive filtering, metadata, and available-functions/dimensions/optimizers helpers; falls back to demo data when CI results are absent
- Exported `Benchmarks` named interface from `types/benchmark.ts`

**CLAUDE.md** — project conventions, tooling (uv, ruff, VitePress SSR pattern, gh CLI token rule)

### SSR constraint (critical)
ECharts accesses `document` at module load time. All chart components are registered via `defineAsyncComponent` inside `typeof window !== 'undefined'` in `theme/index.ts`. Only `APIDoc` (no browser globals) is registered synchronously. Do not add static `import 'echarts'` at the top level.

### Next step (Phase 6 — separate PR)
Fix `docs.yaml` node 20→24, add Griffe regeneration step before build, connect benchmark CI to `docs/public/benchmarks/`, verify GitHub Pages deployment at https://anselmoo.github.io/useful-optimizer/. See `docs/superpowers/plans/2026-06-30-phase6-deploy-github-pages.md`.

Closes #134
Supersedes #135 #136 #138 (closing those separately)
