### PR TITLE
fix: docs build order, RunResult error handling, Python 3.12–3.14, PR CI coverage

### DIFF
--- a/.github/workflows/benchmark-visualizations.yaml
+++ b/.github/workflows/benchmark-visualizations.yaml
@@ -10,7 +10,7 @@ on:
       - main
     paths:
       - 'benchmarks/**'
-      - 'opt/**'
+      - 'src/opt/**'
 
 jobs:
   benchmark-visualizations:
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,11 +19,9 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: pages
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -97,6 +95,9 @@ jobs:
 
   deploy:
     if: github.event_name != 'pull_request'
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,6 +8,13 @@ on:
       - 'docs/**'
       - 'src/opt/**'
       - '.github/workflows/docs.yaml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'src/opt/**'
+      - '.github/workflows/docs.yaml'
   workflow_dispatch:
 
 permissions:
@@ -75,13 +82,13 @@ jobs:
         working-directory: docs
         run: npm ci
 
-      - name: Validate documentation migration
-        working-directory: docs
-        run: npm run validate:migration
-
       - name: Build documentation
         working-directory: docs
         run: npm run docs:build
+
+      - name: Validate documentation migration
+        working-directory: docs
+        run: npm run validate:migration
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
@@ -89,6 +96,7 @@ jobs:
           path: docs/.vitepress/dist
 
   deploy:
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,9 @@ Python library of 120+ optimization algorithms (PSO, DE, SGO, etc.) with a ViteP
 ## Tooling
 
 - **Package manager**: `uv` (not pip/poetry)
+- **Python**: `>=3.12,<3.15` (CI matrix: 3.12, 3.13, 3.14)
 - **Linter/formatter**: `ruff` — runs on pre-commit; auto-fixes on commit
+- **Type checker**: `ty` (`uv run ty check src/opt/`)
 - **Tests**: `pytest` with `--doctest-modules` (doctests in every optimizer file are part of the test suite)
 - **Docs**: VitePress 1.5 in `docs/`, Node 24+
 
@@ -16,14 +18,20 @@ Python library of 120+ optimization algorithms (PSO, DE, SGO, etc.) with a ViteP
 ```bash
 # Python
 uv sync --all-extras          # install all deps including dev/benchmark/validate
-uv run pytest                 # run tests + doctests
-uv run ruff check opt/        # lint
-uv run ruff format opt/       # format
+uv run pytest src/opt/test/ -v --tb=short   # unit tests
+uv run pytest --doctest-modules -v          # doctests
+uv run ruff check src/opt/   # lint
+uv run ruff format src/opt/  # format
+uv run ty check src/opt/     # type check (non-blocking)
 
 # Docs
 cd docs && npm run docs:dev    # dev server
 cd docs && npm run docs:build  # production build (runs SSR — must be SSR-safe)
 cd docs && npm run docs:api    # regenerate Griffe JSON API files
+
+# Full docs CI pipeline locally (mirrors docs.yaml build job):
+uv run python scripts/generate_docs.py --all --json --griffe --full-api --sidebar
+cd docs && npm ci && npm run docs:build && npm run validate:migration
 
 # Benchmarks
 uv run python benchmarks/run_benchmark_suite.py --output-dir benchmarks/output
@@ -32,7 +40,7 @@ uv run python benchmarks/run_benchmark_suite.py --output-dir benchmarks/output
 ## Repository Structure
 
 ```
-opt/                        # Python package (120+ optimizers)
+src/opt/                    # Python package (120+ optimizers) — src layout since #144
   abstract/                 # AbstractOptimizer base class
   swarm_intelligence/       # 56 files
   evolutionary/             # 6 files
@@ -75,9 +83,11 @@ scripts/                    # Dev tooling scripts
   unified_validator.py      # Pydantic schema validation for docstrings
 
 .github/workflows/
-  benchmark-pipeline.yml    # COCO/BBOB CI pipeline
+  tests.yaml                # pytest matrix 3.12/3.13/3.14 + ruff lint (PRs + main)
+  docs.yaml                 # VitePress build + Pages deploy (PRs + main; deploy skipped on PRs)
+  docs-validation.yml       # Pydantic docstring schema validation
+  benchmark-pipeline.yml    # COCO/BBOB CI pipeline (schedule/dispatch only)
   benchmark-visualizations.yaml  # Weekly benchmark run + artifact upload
-  docs.yaml                 # VitePress build + GitHub Pages deploy
 ```
 
 ## Pre-commit Hooks
@@ -130,7 +140,7 @@ benchmarks/run_benchmark_suite.py
 
 ### API Documentation Flow
 ```
-opt/ (Python source)
+src/opt/ (Python source)
   → griffe dump → docs/api/*.json
       ↓
   docs/.vitepress/loaders/api.data.ts   (VitePress data loader)
@@ -141,7 +151,6 @@ opt/ (Python source)
 ## GitHub / git
 
 - **Main branch**: `main`
-- **Active dev branch**: `finishing-version-020-2` (ahead of main — all Phase 4-5 doc work lives here)
 - **Active epic**: Issue #52 — VitePress Documentation Site with Scientific Visualization Suite
 
 ### gh CLI
@@ -155,7 +164,7 @@ Alternatively use the `mcp__github__*` MCP tools which bypass this conflict.
 
 | Issue | Description | Status |
 |-------|-------------|--------|
-| #134 | Wire ECharts to real benchmark data | ✅ Done (commit d141809) |
-| #92 | package-lock.json for npm CI | Open PR |
-| #86 | CI/CD & GitHub Pages deployment | Waiting |
+| #134 | Wire ECharts to real benchmark data | ✅ Done |
+| #92 | package-lock.json for npm CI | ✅ Done (docs/package-lock.json present) |
+| #86 | CI/CD & GitHub Pages deployment | ✅ In progress — PR #145 |
 | #55 | Zensical alternative (alternative doc stack) | Parked |

--- a/benchmarks/aggregate_results.py
+++ b/benchmarks/aggregate_results.py
@@ -16,8 +16,8 @@ import argparse
 import json
 import sys
 
+from datetime import UTC
 from datetime import datetime
-from datetime import timezone
 from pathlib import Path
 
 import numpy as np
@@ -163,7 +163,7 @@ def aggregate_results(input_file: Path, _output_dir: Path | None = None) -> dict
             "max_iterations": raw_data["metadata"].get("max_iterations", 0),
             "n_runs": raw_data["metadata"].get("n_runs", 0),
             "dimensions": raw_data["metadata"].get("dimensions", []),
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": datetime.now(UTC).isoformat(),
             "python_version": sys.version.split()[0],
             "numpy_version": np.__version__,
         },

--- a/benchmarks/run_benchmark_suite.py
+++ b/benchmarks/run_benchmark_suite.py
@@ -428,7 +428,7 @@ def run_benchmark_suite(
     # Save results to JSON
     output_file = output_dir / "results.json"
     with output_file.open("w") as f:
-        json.dump(results.model_dump(), f, indent=2)
+        json.dump(results.model_dump(exclude_none=True), f, indent=2)
 
     print(f"\nBenchmark suite completed. Results saved to {output_file}")
     return results

--- a/benchmarks/run_benchmark_suite.py
+++ b/benchmarks/run_benchmark_suite.py
@@ -83,11 +83,11 @@ class RunResult(BaseModel):
     """Individual run result."""
 
     optimizer: str
-    best_fitness: float
-    best_solution: list[float]
-    elapsed_time: float
-    n_evaluations: int
-    converged: bool
+    best_fitness: float | None = None
+    best_solution: list[float] | None = None
+    elapsed_time: float | None = None
+    n_evaluations: int | None = None
+    converged: bool | None = None
     evaluations_to_target: int | None = None
     convergence_history: list[float] | None = None
     status: str

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@catppuccin/vitepress": "^0.1.2",
-        "@types/node": "^20.10.0",
+        "@types/node": "^24.13.2",
         "echarts": "^5.6.0",
         "json-schema-to-typescript": "^15.0.4",
         "markdown-it-katex": "^2.0.3",
@@ -1430,13 +1430,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/offscreencanvas": {
@@ -3296,9 +3296,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@catppuccin/vitepress": "^0.1.2",
-    "@types/node": "^20.10.0",
+    "@types/node": "^24.13.2",
     "echarts": "^5.6.0",
     "json-schema-to-typescript": "^15.0.4",
     "markdown-it-katex": "^2.0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A dedicated set of optimization algorithms for numeric problems."
 authors = [{ name = "Anselm Hahn", email = "Anselm.Hahn@gmail.com" }]
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.12,<3.15"
 dependencies = [
     "numpy>=1.26.4",
  "scipy>=1.12.0",
@@ -226,4 +226,4 @@ keep-runtime-typing = true
 strict = true
 
 [tool.ty.environment]
-python-version = "3.10"
+python-version = "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ exclude = [
 line-length = 88
 indent-width = 4
 # Define Python target versions.
-target-version = "py310"
+target-version = "py312"
 src = ["src"]
 # Add more options as needed
 

--- a/scripts/batch_update_docstrings.py
+++ b/scripts/batch_update_docstrings.py
@@ -618,7 +618,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 processed.append(info)
             else:
                 failed.append(filepath)
-        except Exception as e:  # noqa: PERF203
+        except Exception as e:
             # Exception handling in loop is necessary for graceful error handling
             print(f"❌ Error processing {filepath}: {e}", file=sys.stderr)
             failed.append(filepath)


### PR DESCRIPTION
## Summary

- **`benchmarks/run_benchmark_suite.py`**: Make `RunResult` result fields (`best_fitness`, `best_solution`, `elapsed_time`, `n_evaluations`, `converged`) optional with `None` defaults — failed optimizer runs returned a partial error dict that crashed Pydantic validation at line 379
- **`docs.yaml`**: Move `docs:build` before `validate:migration` — the `mathRendering` check reads `dist/benchmarks/functions.html` which didn't exist yet, causing a permanent 4/5 (80%) validation score
- **`docs.yaml`**: Add `pull_request` trigger (same path filters as push) so PRs run `npm-check` + `build` + `validate`; guard `deploy` job with `if: github.event_name != 'pull_request'` to skip Pages deployment on PRs
- **`pyproject.toml`**: `requires-python = ">=3.12,<3.15"`; `tool.ty.environment` → `python-version = "3.12"`
- **`tests.yaml`**: CI matrix updated to `["3.12", "3.13", "3.14"]`
- **`benchmark-visualizations.yaml`**: `actions/checkout@v6` → `@v4` (v6 does not exist — workflow would fail on trigger); `opt/**` → `src/opt/**` (src-layout migration from #144 broke the push trigger)

## Root causes

| Failure | Root cause |
|---------|-----------|
| `RunResult` ValidationError | Exception handlers return `{error, optimizer, status}` but model required `best_fitness` etc. with no defaults |
| `mathRendering` 0/5 | `validate:migration` ran before `docs:build` — checked a file that didn't exist yet |
| PRs never tested docs | `docs.yaml` had no `pull_request` trigger — failures only surfaced post-merge |
| `benchmark-visualizations` broken | `checkout@v6` invalid + wrong path filter after src-layout migration |

## Test plan

- [ ] This PR is the first to trigger the docs build on a PR — `npm-check` and `build` jobs should pass, `deploy` should be skipped
- [ ] `validate:migration` should report `Passed: 5/5` including `mathRendering`
- [ ] `tests.yaml` matrix runs on Python 3.12, 3.13, 3.14
- [ ] After merge: `deploy` job runs and publishes to GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)